### PR TITLE
Add missing semicolon to App export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,4 +7,4 @@ function App() {
   );
 }
 
-export default App
+export default App;


### PR DESCRIPTION
## Summary
- fix export statement semicolon in `src/App.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_6885736ddc188327b3c5561b4a61f1c9